### PR TITLE
[BUGFIX] Prevent TypeError when column options are not given

### DIFF
--- a/Classes/Command/ExportTableCommand.php
+++ b/Classes/Command/ExportTableCommand.php
@@ -91,8 +91,8 @@ class ExportTableCommand extends AbstractTableCommand
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
-        $this->setSkipColumns(GeneralUtility::trimExplode(',', $input->getOption('skip-columns'), true));
-        $this->setExplodeColumns(GeneralUtility::trimExplode(',', $input->getOption('explode-columns'), true));
+        $this->setSkipColumns(GeneralUtility::trimExplode(',', $input->getOption('skip-columns') ?? '', true));
+        $this->setExplodeColumns(GeneralUtility::trimExplode(',', $input->getOption('explode-columns') ?? '', true));
         if ($input->getOption('use-only-columns')) {
             $this->setUseOnlyColumns(GeneralUtility::trimExplode(',', $input->getOption('use-only-columns'), true));
         }


### PR DESCRIPTION
## Problem

On current `main` the export command fails on every plain invocation:

```
$ vendor/bin/typo3 yaml:export be_groups /path/to/be_groups.yaml

GeneralUtility::trimExplode(): Argument #2 ($string) must be of type string,
null given, called in .../Classes/Command/ExportTableCommand.php on line 95
```

`--explode-columns` is registered without a default value, so `$input->getOption('explode-columns')` returns `null`. `GeneralUtility::trimExplode()` declares its second parameter as a non-nullable `string`, which makes this a hard `TypeError` rather than a deprecation.

`--skip-columns` is affected as well. It does have a default, but it is declared as `InputOption::VALUE_OPTIONAL`, so the value is `null` as soon as the flag is passed without an argument:

```
$ vendor/bin/typo3 yaml:export --skip-columns be_groups /path/to/be_groups.yaml
```

## Fix

Fall back to an empty string in both places. `trimExplode()` then returns an empty array, which is the behaviour the surrounding code already expects.

## Testing

Verified on TYPO3 v13.4 / PHP 8.4. Before the change the command aborts with the `TypeError` above; afterwards the export completes successfully.
